### PR TITLE
Close PR if effective change is now empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,8 +49,6 @@ async function action() {
       const [owner, repo] = upstream.split("/", 2);
 
       const commitFiles = {};
-      let message =
-        "Automated OAS update: " + files.map((f) => f.dest).join(", ");
 
       for (let f of files) {
         // Check if the file changed in this PR
@@ -91,6 +89,9 @@ async function action() {
         console.log(`No files changed for '${upstream}'`);
         continue;
       }
+
+      let message =
+        "Automated OAS update: " + Object.keys(commitFiles).join(", ");
 
       const opts = {
         owner,

--- a/index.test.js
+++ b/index.test.js
@@ -352,7 +352,7 @@ describe("Raise PR on change", () => {
       expect(core.setOutput).toBeCalledWith("status", "success");
     });
 
-    fit("handles missing files in the upstream repo", async () => {
+    it("handles missing files in the upstream repo", async () => {
       restoreTest = mockPr({
         ...defaultConfig,
         INPUT_MODE: "check-upstream",
@@ -528,7 +528,7 @@ function mockCreateCommit({
   // Create Commit
   nock("https://api.github.com")
     .post(`/repos/${owner}/${repo}/git/commits`, {
-      message: "Automated OAS update: specs/foo.yaml, specs/bar.yaml",
+      message: `Automated OAS update: ${Object.keys(fileContents).join(", ")}`,
       parents: ["sha-main-branch"],
     })
     .reply(201, {


### PR DESCRIPTION
* Only use the committed files as part of the commit message, not all files that the repo is monitoring.
* If the PR contains no changed files, close it