### PR TITLE
Fix mocked GET /repos/owner/repo/contents/path response in tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,13 @@ async function action() {
                 path: f.dest,
               });
 
-            if (content == upstreamContent) {
+            // Convert from base64
+            const upstreamContentDecoded = Buffer.from(
+              upstreamContent.content,
+              "base64"
+            ).toString("utf-8");
+
+            if (content == upstreamContentDecoded) {
               // No change to the contents, continue
               continue;
             }

--- a/index.test.js
+++ b/index.test.js
@@ -573,7 +573,9 @@ function mockFileContent({ owner, repo, path, content, code }) {
   code = code || 200;
   nock("https://api.github.com")
     .get(`/repos/${owner}/${repo}/contents/${encodeURIComponent(path)}`)
-    .reply(code, content);
+    .reply(code, {
+      content: Buffer.from(content).toString("base64"),
+    });
 }
 
 function mockPrExists({ owner, repo, prBranch, prExists }) {


### PR DESCRIPTION
The tests assumed that the GitHub API returned raw content rather than a JSON blob with a `content` key.

This PR fixes the mocks in the tests, and updates the code to fix the behaviour