### PR TITLE
chore: add commitMessage to action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,3 +29,6 @@ inputs:
   prBody:
     description: "The PR body to use"
     required: true
+  commitMessage:
+    description: "The commit message use"
+    required: false


### PR DESCRIPTION
#21 added customization of commit message but it seems that the action requires the argument to be defined in `action.yml` to not complain when it's used:

https://github.com/Kong/platform-api/actions/runs/11589943446/job/32266492215#step:8:1

```
Warning: Unexpected input(s) 'commitMessage', valid inputs are ['token', 'mode', 'configFile', 'prBranch', 'targetBranch', 'prTitle', 'prBody']
```